### PR TITLE
Optimize request monitoring with Redis caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # Alerting System for Monitoring Failed API Requests
 
-## Overview
-This is a Spring Boot application designed to monitor and track failed API requests and notify, with features including:
-- Request validation
+### Overview
+Spring Boot application for monitoring failed API requests with features:
+- Request validation and caching
 - Failed request logging
 - IP-based alert system
-- Email notifications for suspicious activities
+- Redis caching for optimized performance
+- Email notifications for multiple failed API requests
 
 ### Prerequisites
-- Java 17, MongoDB, Maven, Gmail account (for SMTP email alerts)
+- Java 17, Maven, Redis, MongoDB, Gmail account (for SMTP email alerts)
 
 ### Technology Stack
-- Spring Boot 3.2.1, MongoDB, Java Mail Sender, Lombok
+- Spring Boot 3.2.1, Redis, MongoDB, Java Mail Sender, Lombok, Jackson JSR310
 
 ## Configuration Steps
 
@@ -36,14 +37,28 @@ server.tomcat.threads.max=200
 server.tomcat.max-connections=10000
 ```
 
-### 3. Configure MongoDB
+### 3. Setup Redis
+- Install Redis
+- Start Redis server
+- Verify connection: `redis-cli ping`
+```properties
+# Redis Configuration
+spring.redis.host=localhost
+spring.redis.port=6379
+
+# Jackson Configuration
+spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
+spring.jackson.date-format=yyyy-MM-dd HH:mm:ss
+```
+
+### 4. Configure MongoDB
 - Open `src/main/resources/application.properties`
 - Ensure MongoDB is running locally
 - Default connection: `mongodb://localhost:27017/<your-db-name>`
 
-### 4. Configure Email Settings
-1. Open `src/main/resources/application.properties`
-2. Update email configuration:
+### 5. Configure Email Settings
+- Open `src/main/resources/application.properties`
+- Update email configuration:
 ```properties
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
@@ -51,13 +66,13 @@ spring.mail.username=your-email@gmail.com
 spring.mail.password=your-app-password
 ```
 
-### 5. Generate App Password for Gmail
+### 6. Generate App Password for Gmail
 - Go to Google Account
 - Security > 2-Step Verification
 - App Passwords > Select App (Mail) > Generate
 - Use generated password in `application.properties`
 
-### 5. Build and Run the Application
+### 7. Build and Run the Application
 ```bash
 # Build the project
 mvn clean package
@@ -95,6 +110,12 @@ curl -X POST "http://localhost:8080/api/submit?clientId=123&version=1.0" \
      -d '{"name":"John Doe","description":"Sample Description"}'
 ```
 
+## Architecture
+- Failed requests cached in Redis (10-minute window)
+- Batch writes to MongoDB on threshold breach
+- Email alerts sent for suspicious activity
+- Path validation for /api/submit endpoint
+
 ## Logging
 - Failed requests are logged in MongoDB
 - Email alerts sent when failure threshold is reached
@@ -111,6 +132,7 @@ Modify `application.properties` to adjust:
 - SMTP settings
 
 ## Troubleshooting
-- Ensure MongoDB is running
+- Verify Redis and MongoDB services
 - Check SMTP credentials
-- Verify network configurations
+- Confirm network configurations
+- Monitor Redis cache status

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,22 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<!-- Redis Cache -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>io.lettuce</groupId>
+		    <artifactId>lettuce-core</artifactId>
+		</dependency>
+		<!-- jackson-datatype-jsr310 (Date Serialization for Redis) -->
+		<dependency>
+		    <groupId>com.fasterxml.jackson.datatype</groupId>
+		    <artifactId>jackson-datatype-jsr310</artifactId>
+		    <version>2.18.2</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/requestmonitor/config/RedisConfig.java
+++ b/src/main/java/com/requestmonitor/config/RedisConfig.java
@@ -1,0 +1,61 @@
+package com.requestmonitor.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+
+
+@Configuration
+public class RedisConfig {
+    
+    @Value("${spring.data.redis.host:localhost}")
+    private String redisHost;
+    
+    @Value("${spring.data.redis.port:6379}")
+    private int redisPort;
+    
+    @Bean
+    ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper;
+    }
+    
+    @Bean
+    LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(redisHost, redisPort);
+        return new LettuceConnectionFactory(configuration);
+    }
+    
+    @SuppressWarnings("removal")
+	@Bean
+    RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        
+        // Create Jackson2JsonRedisSerializer with custom ObjectMapper
+        Jackson2JsonRedisSerializer<Object> serializer = new Jackson2JsonRedisSerializer<>(Object.class);
+        serializer.setObjectMapper(objectMapper());
+        
+        // Configure template
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
+        template.setEnableDefaultSerializer(false);
+        template.afterPropertiesSet();
+        
+        return template;
+    }
+}

--- a/src/main/java/com/requestmonitor/model/FailedRequest.java
+++ b/src/main/java/com/requestmonitor/model/FailedRequest.java
@@ -3,6 +3,7 @@ package com.requestmonitor.model;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 @Data
@@ -14,8 +15,8 @@ public class FailedRequest {
     private String ipAddress;
     private String requestPath;
     private String failureReason;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime timestamp;
     private String requestMethod;
     private String requestBody;
-    private boolean alertSent;
 }

--- a/src/main/java/com/requestmonitor/service/RequestCacheService.java
+++ b/src/main/java/com/requestmonitor/service/RequestCacheService.java
@@ -1,0 +1,67 @@
+package com.requestmonitor.service;
+
+import com.requestmonitor.model.FailedRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RequestCacheService {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private static final String FAILED_REQUESTS_PREFIX = "failed_requests:";
+    private static final Duration CACHE_TTL = Duration.ofMinutes(10);
+
+    public void cacheFailedRequest(String ipAddress, FailedRequest failedRequest) {
+        String key = FAILED_REQUESTS_PREFIX + ipAddress;
+        
+        // Get existing failed requests for this IP
+        List<FailedRequest> failedRequests = getFailedRequests(ipAddress);
+        if (failedRequests == null) {
+            failedRequests = new ArrayList<>();
+        }
+        
+        // Add new failed request
+        failedRequests.add(failedRequest);
+        
+        // Update cache with new TTL
+        redisTemplate.opsForValue().set(key, failedRequests, CACHE_TTL);
+    }
+    
+    public List<FailedRequest> getFailedRequests(String ipAddress) {
+        Object cachedValue = redisTemplate.opsForValue().get(FAILED_REQUESTS_PREFIX + ipAddress);
+        
+        if (cachedValue == null) {
+            return new ArrayList<>();
+        }
+        
+        try {
+            // Convert the cached value to JSON string
+            String jsonString = objectMapper.writeValueAsString(cachedValue);
+            // Convert JSON string to List<FailedRequest>
+            return objectMapper.readValue(
+                jsonString,
+                objectMapper.getTypeFactory().constructCollectionType(List.class, FailedRequest.class)
+            );
+        } catch (Exception e) {
+            // Log the error and return empty list
+            System.err.println("Error deserializing cached requests: " + e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+    
+    public void clearFailedRequests(String ipAddress) {
+        redisTemplate.delete(FAILED_REQUESTS_PREFIX + ipAddress);
+    }
+    
+    public int getFailedRequestCount(String ipAddress) {
+        List<FailedRequest> requests = getFailedRequests(ipAddress);
+        return requests.size();
+    }
+}


### PR DESCRIPTION
## Optimize request monitoring with Redis caching
- Add Redis configuration for caching failed requests
- Implement proper LocalDateTime serialization with Jackson JSR310
- Fix LinkedHashMap type conversion issue in cache retrieval
- Add path validation for /api/submit endpoint
- Optimize DB writes by caching requests and batch saving on threshold
- Handle serialization/deserialization of FailedRequest objects
- Update error handling and monitoring service integration

Dependencies added:
- spring-boot-starter-data-redis
- jackson-datatype-jsr310
- jackson-databind

Configuration changes:
- Redis host/port settings
- Jackson date formatting
- Object mapping configurations